### PR TITLE
Session handling improvements

### DIFF
--- a/Lifter.py
+++ b/Lifter.py
@@ -24,10 +24,11 @@ class Lifter(object):
             self.label = label
             self.url = url
 
-    def __init__(self, url, resolution, logger, season, ep_range, exclude, output, newest, settings, database, quiet,update=False, threads=None):
+    def __init__(self, url, resolution, session, logger, season, ep_range, exclude, output, newest, settings, database, quiet,update=False, threads=None):
         # Define our variables
         self.url = url
         self.resolution = resolution
+        self.session = session
         self.logger = logger
         self.season = season
         self.ep_range = ep_range
@@ -146,7 +147,7 @@ class Lifter(object):
         show_info = self.info_extractor(extra)
         output = self.check_output(show_info[0])
 
-        Downloader(logger=self.logger, download_url=download_url, backup_url=backup_url, hidden_url=hidden_url,output=output, header=self.header, user_agent=self.user_agent,
+        Downloader(session=self.session, logger=self.logger, download_url=download_url, backup_url=backup_url, hidden_url=hidden_url,output=output, header=self.header, user_agent=self.user_agent,
                    show_info=show_info, settings=self.settings, quiet=self.quiet)
 
     def test(self, i, ii):
@@ -212,7 +213,7 @@ class Lifter(object):
                     show_info = self.info_extractor(item)
                     output = self.check_output(show_info[0])
 
-                    Downloader(logger=self.logger, download_url=download_url, backup_url=backup_url, hidden_url=hidden_url ,output=output, header=self.header, user_agent=self.user_agent,
+                    Downloader(session=self.session, logger=self.logger, download_url=download_url, backup_url=backup_url, hidden_url=hidden_url ,output=output, header=self.header, user_agent=self.user_agent,
                             show_info=show_info, settings=self.settings, quiet=self.quiet)
             else:
                 count = 0
@@ -263,7 +264,7 @@ class Lifter(object):
                 show_info = self.info_extractor(item)
                 output = self.check_output(show_info[0])
 
-                Downloader(logger=self.logger, download_url=download_url, backup_url=backup_url, hidden_url=hidden_url ,output=output, header=self.header, user_agent=self.user_agent,
+                Downloader(session=self.session, logger=self.logger, download_url=download_url, backup_url=backup_url, hidden_url=hidden_url ,output=output, header=self.header, user_agent=self.user_agent,
                         show_info=show_info, settings=self.settings, quiet=self.quiet)
             if (self.original_thread != None and self.original_thread != 0): 
                 self.threads = self.original_thread

--- a/__main__.py
+++ b/__main__.py
@@ -9,6 +9,7 @@ from Lifter import *
 from version import __version__
 from Settings import Settings
 from SaveDownloads import SaveDownloadToFile
+from requests import session
 
 class Main:
     if __name__ == '__main__':
@@ -49,6 +50,8 @@ class Main:
         
         args = parser.parse_args()
 
+        session = session()
+
         if args.quiet:
             quiet = 'True'
 
@@ -58,7 +61,7 @@ class Main:
             with open(args.batch[0], 'r') as anime_list:
                 for anime in anime_list:
                     print(anime.replace('\n', ''))
-                    Lifter(url=anime.replace('\n', '').replace('https://wcostream.tv', 'https://www.wcostream.tv'), resolution=args.resolution, logger=logger, season=args.season,
+                    Lifter(url=anime.replace('\n', '').replace('https://wcostream.tv', 'https://www.wcostream.tv'), resolution=args.resolution, session=session, logger=logger, season=args.season,
                     ep_range=args.episoderange, exclude=args.exclude, output=args.output, newest=args.newest,
                     settings=settings, database=database, threads=args.threads, quiet=quiet)
             print('Done')
@@ -67,7 +70,7 @@ class Main:
         if args.update_shows: 
             print("Updating all shows, this will take a while.")
             for x in database.return_show_url():
-                Lifter(url=x, resolution=args.resolution, logger=logger, season=args.season,
+                Lifter(url=x, resolution=args.resolution, session=session, logger=logger, season=args.season,
                 ep_range=args.episoderange, exclude=args.exclude, output=args.output, newest=args.newest,
                 settings=settings, database=database, update=True, quiet=quiet)
             print('Done')
@@ -111,6 +114,6 @@ class Main:
             if type(args.threads) ==list:
                 args.threads = args.threads[0]
 
-            Lifter(url=args.input[0].replace('https://wcostream.tv', 'https://www.wcostream.tv'), resolution=args.resolution, logger=logger, season=args.season,
+            Lifter(url=args.input[0].replace('https://wcostream.tv', 'https://www.wcostream.tv'), resolution=args.resolution, session=session, logger=logger, season=args.season,
                    ep_range=args.episoderange, exclude=args.exclude, output=args.output, newest=args.newest,
                    settings=settings, database=database, threads=args.threads, quiet=quiet)


### PR DESCRIPTION
- Use same session object across downloads
- Use 'stream=True' to speed up requests

This prevents the occasional extra-long waits during `Checking if video is already downloaded`